### PR TITLE
added runtime section

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -17,5 +17,8 @@
             "includes": ["."],
             "plugins": ["plugins/sscanf.dll"]
         }
-    ]
+    ],
+    "runtime": {
+        "plugins": ["maddinat0r/sscanf"]
+    }
 }


### PR DESCRIPTION
so dependent packages know to pull plugin binaries without needing to explicitly specify them