### PR TITLE
Fix CFLAGS/LDFLAGS on Linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ GPP = g++
 GCC = gcc
 SSCANF_OUTFILE = "sscanf.so"
 
-COMPILE_FLAGS = -m32 -fPIC -c -O3 -w -D LINUX -D PROJECT_NAME=\"sscanf\" -I ./SDK/amx/
+COMPILE_FLAGS = -m32 -fPIC -c -O2 -w -D LINUX -D PROJECT_NAME=\"sscanf\" -I ./SDK/amx/
 
 SSCANF = -D SSCANF $(COMPILE_FLAGS)
 
@@ -22,4 +22,4 @@ SSCANF: clean
 	$(GPP) $(SSCANF) ./SDK/amx/*.c
 	$(GPP) $(SSCANF) ./SDK/*.cpp
 	$(GPP) $(SSCANF) *.cpp
-	$(GPP) -m32 -O2 -fshort-wchar -shared -o $(SSCANF_OUTFILE) *.o
+	$(GPP) -m32 -fPIC -shared -o $(SSCANF_OUTFILE) *.o


### PR DESCRIPTION
Everything in the title. -fPIC needs to be in LDFLAGS, -O3 is excessively aggressive and -fshort-wchar is actively harmful.