### PR TITLE
Helper ``sscanf_`` macro and removed ``forward``

### DIFF
--- a/sscanf2.inc
+++ b/sscanf2.inc
@@ -82,7 +82,9 @@ const SSCANF_VERSION =
 
 stock const SSCANF_VERSION_BCD = SSCANF_VERSION;
 
-#define SSCANF:%0(%1) forward sscanf_%0(%1);public sscanf_%0(%1)
+#define sscanf_%0\32; sscanf_
+
+#define SSCANF:%0(%1) sscanf_%0(%1); public sscanf_%0(%1)
 
 #if defined sscanf
 	#error sscanf (possibly the PAWN version) already defined.


### PR DESCRIPTION
"Helper" ``sscanf_`` macro is used to turn ``sscanf_ name`` to ``sscanf_name`` when ``name`` is declared as ``SSCANF: name(string[])`` instead of ``SSCANF:name(string[])`` (space makes the problem).
Removed ``forward``; since ``forward`` is an optional keyword.