### PR TITLE
properly escape % symbol in warning message

### DIFF
--- a/enum.cpp
+++ b/enum.cpp
@@ -490,7 +490,7 @@ int
 				SscanfError(71, "End of text is not supported in enums.");
 				return SSCANF_FAIL_RETURN;
 			case '%':
-				SscanfWarning(25, "sscanf specifiers do not require '%' before them.");
+				SscanfWarning(25, "sscanf specifiers do not require '%%' before them.");
 				continue;
 			case '-':
 				{
@@ -584,7 +584,7 @@ int
 						len = 0;
 						break;
 					case '%':
-						SscanfWarning(25, "sscanf specifiers do not require '%' before them.");
+						SscanfWarning(25, "sscanf specifiers do not require '%%' before them.");
 						len = 0;
 						break;
 					case '-':

--- a/sscanf.cpp
+++ b/sscanf.cpp
@@ -1149,7 +1149,7 @@ static cell
 				}
 				return SSCANF_TRUE_RETURN;
 			case '%':
-				SscanfWarning(25, "sscanf specifiers do not require '%' before them.");
+				SscanfWarning(25, "sscanf specifiers do not require '%%' before them.");
 				continue;
 			default:
 				SscanfWarning(9, "Unknown format specifier '%c', skipping.", *(format - 1));
@@ -1391,7 +1391,7 @@ static cell
 				}
 				return SSCANF_TRUE_RETURN;
 			case '%':
-				SscanfWarning(25, "sscanf specifiers do not require '%' before them.");
+				SscanfWarning(25, "sscanf specifiers do not require '%%' before them.");
 				break;
 			default:
 				SscanfWarning(9, "Unknown format specifier '%c', skipping.", *(format - 1));


### PR DESCRIPTION
Before the warning message, when % character is used as prefix for specifier, was displayed like this:
```
sscanf specifiers do not require '' before them.
```
instead of 
```
sscanf specifiers do not require '%' before them.
```
This PR escapes `%` symbol in those strings.