### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,11 @@ name: Build and Release
 on:
   workflow_dispatch:
   push:
-    tags: ['v*']  # Запускаем релиз только при тегах
-  push:
     branches:
       - "*"
       - "*/*"
       - "**"
+    tags: ['v*']
   pull_request:
     branches:
       - "*"
@@ -103,7 +102,6 @@ jobs:
             pawn.json
             README.md
 
-  # НОВЫЙ JOB ДЛЯ СОЗДАНИЯ РЕЛИЗНЫХ ПАКЕТОВ
   create-release-packages:
     runs-on: windows-latest
     needs: [build-windows-release, build-linux-release]
@@ -125,6 +123,7 @@ jobs:
         run: |
           $version = $env:GITHUB_REF -replace 'refs/tags/v',''
           echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "Version: $version"
           
       - name: Install 7-Zip
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,21 +24,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Extract version from tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          $version = "${{ github.ref_name }}".Substring(1)
-          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "VERSION_SHORT=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "ARTIFACT_NAME=sscanf-$version-win32" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Set default version (for non-tag builds)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "VERSION=2.15.1" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "VERSION_SHORT=2.15.1" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "ARTIFACT_NAME=sscanf-2.15.1-win32" | Out-File -FilePath $env:GITHUB_ENV -Append
-
       - name: Check CMake version
         run: cmake --version
 
@@ -56,46 +41,17 @@ jobs:
           cd build
           cmake -DCMAKE_BUILD_TYPE=Release .. -G "Visual Studio 17 2022" -A Win32
           cmake --build . --config Release
-
-      - name: Create Windows package structure
-        run: |
-          mkdir sscanf-$env:VERSION_SHORT-win32
-          mkdir sscanf-$env:VERSION_SHORT-win32/plugins
-          mkdir sscanf-$env:VERSION_SHORT-win32/components
-          mkdir sscanf-$env:VERSION_SHORT-win32/pawno
-          mkdir sscanf-$env:VERSION_SHORT-win32/pawno/include
-          mkdir sscanf-$env:VERSION_SHORT-win32/qawno
-          mkdir sscanf-$env:VERSION_SHORT-win32/qawno/include
           
-          copy build/Release/sscanf.dll sscanf-$env:VERSION_SHORT-win32/amxsscanf.dll
-          copy build/Release/sscanf.dll sscanf-$env:VERSION_SHORT-win32/plugins/sscanf.dll
-          copy build/Release/sscanf.dll sscanf-$env:VERSION_SHORT-win32/components/sscanf.dll
-          copy sscanf2.inc sscanf-$env:VERSION_SHORT-win32/
-          copy sscanf2.inc sscanf-$env:VERSION_SHORT-win32/pawno/include/
-          copy sscanf2.inc sscanf-$env:VERSION_SHORT-win32/qawno/include/
-          copy LICENSE sscanf-$env:VERSION_SHORT-win32/
-          copy pawn.json sscanf-$env:VERSION_SHORT-win32/
-          copy README.md sscanf-$env:VERSION_SHORT-win32/
-
-      - name: Check created directory structure
-        run: |
-          echo "Directory structure:"
-          Get-ChildItem -Recurse sscanf-$env:VERSION_SHORT-win32
-
-      - name: Create Windows zip archive
-        run: |
-          7z a -tzip sscanf-$env:VERSION_SHORT-win32.zip .\sscanf-$env:VERSION_SHORT-win32\*
-          
-      - name: Check created archive
-        run: |
-          echo "Created files:"
-          Get-ChildItem *.zip
-          
-      - name: Upload Windows artifact
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: $env:ARTIFACT_NAME
-          path: sscanf-$env:VERSION_SHORT-win32.zip
+          name: windows-build
+          path: |
+            build/Release/sscanf.dll
+            sscanf2.inc
+            LICENSE
+            pawn.json
+            README.md
 
   build-linux-release:
     runs-on: ubuntu-latest
@@ -105,22 +61,6 @@ jobs:
           clean: true
           submodules: recursive
           fetch-depth: 0
-
-      - name: Extract version from tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          version="${GITHUB_REF#refs/tags/}"
-          version="${version#v}"
-          echo "VERSION=$version" >> $GITHUB_ENV
-          echo "VERSION_SHORT=$version" >> $GITHUB_ENV
-          echo "ARTIFACT_NAME=sscanf-$version-linux" >> $GITHUB_ENV
-
-      - name: Set default version (for non-tag builds)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "VERSION=2.15.1" >> $GITHUB_ENV
-          echo "VERSION_SHORT=2.15.1" >> $GITHUB_ENV
-          echo "ARTIFACT_NAME=sscanf-2.15.1-linux" >> $GITHUB_ENV
 
       - name: Install packages
         run: |
@@ -146,44 +86,137 @@ jobs:
           cd build
           cmake --build . --config Release
 
-      - name: Create Linux package structure
+      - name: Rename and upload artifacts
         run: |
-          # Переименовываем библиотеку
           cd build
           mv ./libsscanf.so ./sscanf.so
-          cd ..
           
-          mkdir -p sscanf-$VERSION_SHORT-linux/plugins
-          mkdir -p sscanf-$VERSION_SHORT-linux/components
-          mkdir -p sscanf-$VERSION_SHORT-linux/pawno/include
-          mkdir -p sscanf-$VERSION_SHORT-linux/qawno/include
-          
-          cp build/sscanf.so sscanf-$VERSION_SHORT-linux/amxsscanf.so
-          cp build/sscanf.so sscanf-$VERSION_SHORT-linux/plugins/sscanf.so
-          cp build/sscanf.so sscanf-$VERSION_SHORT-linux/components/sscanf.so
-          cp sscanf2.inc sscanf-$VERSION_SHORT-linux/
-          cp sscanf2.inc sscanf-$VERSION_SHORT-linux/pawno/include/
-          cp sscanf2.inc sscanf-$VERSION_SHORT-linux/qawno/include/
-          cp LICENSE sscanf-$VERSION_SHORT-linux/
-          cp pawn.json sscanf-$VERSION_SHORT-linux/
-          cp README.md sscanf-$VERSION_SHORT-linux/
-
-      - name: Check created directory structure
-        run: |
-          echo "Directory structure:"
-          find sscanf-$VERSION_SHORT-linux -type f
-
-      - name: Create Linux tar.gz archive
-        run: |
-          tar -czf sscanf-$VERSION_SHORT-linux.tar.gz -C sscanf-$VERSION_SHORT-linux .
-          
-      - name: Check created archive
-        run: |
-          echo "Created files:"
-          ls -la *.tar.gz
-          
-      - name: Upload Linux artifact
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: $ARTIFACT_NAME
-          path: sscanf-$VERSION_SHORT-linux.tar.gz
+          name: linux-build
+          path: |
+            build/sscanf.so
+            sscanf2.inc
+            LICENSE
+            pawn.json
+            README.md
+
+  create-release-packages:
+    runs-on: windows-latest
+    needs: [build-windows-release, build-linux-release]
+    
+    steps:
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-build
+          path: windows-files/
+        
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-build
+          path: linux-files/
+        
+      - name: Check files structure
+        run: |
+          echo "=== Windows files ==="
+          Get-ChildItem -Path "windows-files" -Recurse -Force
+          echo "=== Linux files ==="
+          Get-ChildItem -Path "linux-files" -Recurse -Force
+        
+      - name: Get version
+        run: |
+          $version = $env:GITHUB_SHA.Substring(0, 7)
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "Version: $version"
+            
+      - name: Install 7-Zip
+        run: choco install 7zip -y
+            
+      - name: Create Windows package
+        run: |
+          $dllPath = "windows-files/build/Release/sscanf.dll"
+          if (-not (Test-Path $dllPath)) { 
+            Write-Host "Available files:"
+            Get-ChildItem -Path "windows-files" -Recurse
+            throw "Windows sscanf.dll not found at: $dllPath" 
+          }
+          
+          mkdir windows-package
+          cd windows-package
+          
+          copy "..\$dllPath" amxsscanf.dll
+          copy ..\windows-files\LICENSE LICENSE
+          copy ..\windows-files\pawn.json pawn.json
+          copy ..\windows-files\README.md README.md
+          copy ..\windows-files\sscanf2.inc .\
+          
+          mkdir components
+          copy "..\$dllPath" components\sscanf.dll
+          
+          mkdir plugins
+          copy "..\$dllPath" plugins\sscanf.dll
+          
+          mkdir pawno
+          cd pawno
+          mkdir include
+          copy ..\..\windows-files\sscanf2.inc include\sscanf2.inc
+          cd ..
+          
+          mkdir qawno
+          cd qawno
+          mkdir include
+          copy ..\..\windows-files\sscanf2.inc include\sscanf2.inc
+          cd ..
+          
+          7z a -tzip windows-$env:VERSION.zip *
+          cd ..
+            
+      - name: Create Linux package
+        run: |
+          $soPath = "linux-files/build/sscanf.so"
+          if (-not (Test-Path $soPath)) { 
+            Write-Host "Available files:"
+            Get-ChildItem -Path "linux-files" -Recurse
+            throw "Linux sscanf.so not found at: $soPath" 
+          }
+          
+          mkdir linux-package
+          cd linux-package
+          
+          copy "..\$soPath" amxsscanf.so
+          copy ..\linux-files\LICENSE LICENSE
+          copy ..\linux-files\pawn.json pawn.json
+          copy ..\linux-files\README.md README.md
+          copy ..\linux-files\sscanf2.inc .\
+          
+          mkdir components
+          copy "..\$soPath" components\sscanf.so
+          
+          mkdir plugins
+          copy "..\$soPath" plugins\sscanf.so
+          
+          mkdir pawno
+          cd pawno
+          mkdir include
+          copy ..\..\linux-files\sscanf2.inc include\sscanf2.inc
+          cd ..
+          
+          mkdir qawno
+          cd qawno
+          mkdir include
+          copy ..\..\linux-files\sscanf2.inc include\sscanf2.inc
+          cd ..
+          
+          7z a -ttar -so -an * | 7z a -si linux-$env:VERSION.tar.gz
+          cd ..
+            
+      - name: Upload release packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-packages
+          path: |
+            windows-package/*.zip
+            linux-package/*.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,33 +105,41 @@ jobs:
   create-release-packages:
     runs-on: windows-latest
     needs: [build-windows-release, build-linux-release]
-    if: startsWith(github.ref, 'refs/tags/v')
     
     steps:
       - name: Download Windows artifacts
         uses: actions/download-artifact@v4
         with:
           name: windows-build
-          
+        
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4
         with:
           name: linux-build
-          
+        
+      - name: List downloaded files (debug)
+        run: dir /b
+        
       - name: Get version from tag
         id: get_version
         run: |
-          $version = $env:GITHUB_REF -replace 'refs/tags/v',''
+          if ("$env:GITHUB_REF" -like "refs/tags/v*") {
+            $version = $env:GITHUB_REF -replace 'refs/tags/v',''
+          } else {
+            $version = $env:GITHUB_SHA.Substring(0, 7)
+          }
           echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "Version: $version"
-          
+            
       - name: Install 7-Zip
-        run: |
-          choco install 7zip -y
-          
+        run: choco install 7zip -y
+            
       - name: Create Windows package
         run: |
-          # Создаем структуру для Windows
+          dir /b
+          dir /b *.dll
+          dir /b *.inc
+          
           mkdir windows
           cd windows
           
@@ -139,6 +147,7 @@ jobs:
           copy ..\LICENSE LICENSE
           copy ..\pawn.json pawn.json
           copy ..\README.md README.md
+          copy ..\sscanf2.inc .\
           
           mkdir components
           copy ..\sscanf.dll components\sscanf.dll
@@ -158,13 +167,13 @@ jobs:
           copy ..\..\sscanf2.inc include\sscanf2.inc
           cd ..
           
-          # Создаем архив
           7z a -tzip windows-$env:VERSION.zip *
           cd ..
-          
+            
       - name: Create Linux package
         run: |
-          # Создаем структуру для Linux
+          dir /b *.so
+          
           mkdir linux
           cd linux
           
@@ -172,6 +181,7 @@ jobs:
           copy ..\LICENSE LICENSE
           copy ..\pawn.json pawn.json
           copy ..\README.md README.md
+          copy ..\sscanf2.inc .\
           
           mkdir components
           copy ..\sscanf.so components\sscanf.so
@@ -191,30 +201,13 @@ jobs:
           copy ..\..\sscanf2.inc include\sscanf2.inc
           cd ..
           
-          # Создаем tar.gz архив
           7z a -ttar -so -an * | 7z a -si linux-$env:VERSION.tar.gz
           cd ..
-          
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+            
+      - name: Upload release packages
+        uses: actions/upload-artifact@v4
         with:
-          files: |
+          name: release-packages
+          path: |
             windows-$env:VERSION.zip
             linux-$env:VERSION.tar.gz
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Automated release packages built from GitHub Actions
-            
-            ## Windows
-            - **windows-${{ env.VERSION }}.zip**: Complete package with DLL and includes
-            
-            ## Linux
-            - **linux-${{ env.VERSION }}.tar.gz**: Complete package with SO and includes
-            
-            ### Contents:
-            - Plugin files (amxsscanf.dll/so)
-            - Components directory
-            - Plugins directory
-            - Pawno/Qawno include files
-            - Documentation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,5 +218,5 @@ jobs:
         with:
           name: release-packages
           path: |
-            windows-$env:VERSION.zip
-            linux-$env:VERSION.tar.gz
+            windows-package/*.zip
+            linux-package/*.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-windows-release:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -23,24 +23,26 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Check CMake version
+        run: cmake --version
+
       - name: Setup Python
         uses: actions/setup-python@v2
-
-      - name: Install CMake
-        uses: lukka/get-cmake@v.3.23.2
 
       - name: Install latest conan
         run: |
           python -m pip install --upgrade pip
           pip install conan
+          
       - name: Generate build files
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release .. -G "Visual Studio 16 2019" -A Win32
+          cmake -DCMAKE_BUILD_TYPE=Release .. -G "Visual Studio 17 2022" -A Win32
           cmake --build . --config Release
+          
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sscanf-win-release
           path: build/Release/sscanf.dll
@@ -57,13 +59,10 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install g++-multilib
+          sudo apt-get install g++-multilib cmake
 
       - name: Setup Python
         uses: actions/setup-python@v2
-
-      - name: Install CMake
-        uses: lukka/get-cmake@v.3.23.2
 
       - name: Install latest conan
         run: |
@@ -87,7 +86,7 @@ jobs:
           mv ./libsscanf.so ./sscanf.so
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sscanf-linux-release
           path: build/sscanf.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,5 +218,5 @@ jobs:
         with:
           name: release-packages
           path: |
-            windows-build/windows-$env:VERSION.zip
-            linux-build/linux-$env:VERSION.tar.gz
+            windows-$env:VERSION.zip
+            linux-$env:VERSION.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,5 +218,5 @@ jobs:
         with:
           name: release-packages
           path: |
-            windows-package/windows-$env:VERSION.zip
-            linux-package/linux-$env:VERSION.tar.gz
+            windows-build/windows-$env:VERSION.zip
+            linux-build/linux-$env:VERSION.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,25 +111,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: windows-build
-          path: ./
+          path: windows-files/
         
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4
         with:
           name: linux-build
-          path: ./
+          path: linux-files/
         
       - name: Check files structure
         run: |
-          echo "=== Files in current directory ==="
-          Get-ChildItem -Path . -Force
-          echo "=== Checking for required files ==="
-          if (Test-Path "sscanf.dll") { echo "✓ sscanf.dll found" } else { echo "✗ sscanf.dll missing" }
-          if (Test-Path "sscanf.so") { echo "✓ sscanf.so found" } else { echo "✗ sscanf.so missing" }
-          if (Test-Path "sscanf2.inc") { echo "✓ sscanf2.inc found" } else { echo "✗ sscanf2.inc missing" }
-          if (Test-Path "LICENSE") { echo "✓ LICENSE found" } else { echo "✗ LICENSE missing" }
-          if (Test-Path "pawn.json") { echo "✓ pawn.json found" } else { echo "✗ pawn.json missing" }
-          if (Test-Path "README.md") { echo "✓ README.md found" } else { echo "✗ README.md missing" }
+          echo "=== Windows files ==="
+          Get-ChildItem -Path "windows-files" -Force
+          echo "=== Linux files ==="
+          Get-ChildItem -Path "linux-files" -Force
         
       - name: Get version
         run: |
@@ -142,33 +137,33 @@ jobs:
             
       - name: Create Windows package
         run: |
-          if (-not (Test-Path "sscanf.dll")) { throw "sscanf.dll not found!" }
+          if (-not (Test-Path "windows-files/sscanf.dll")) { throw "Windows sscanf.dll not found!" }
           
           mkdir windows-package
           cd windows-package
           
-          copy ..\sscanf.dll amxsscanf.dll
-          copy ..\LICENSE LICENSE
-          copy ..\pawn.json pawn.json
-          copy ..\README.md README.md
-          copy ..\sscanf2.inc .\
+          copy ..\windows-files\sscanf.dll amxsscanf.dll
+          copy ..\windows-files\LICENSE LICENSE
+          copy ..\windows-files\pawn.json pawn.json
+          copy ..\windows-files\README.md README.md
+          copy ..\windows-files\sscanf2.inc .\
           
           mkdir components
-          copy ..\sscanf.dll components\sscanf.dll
+          copy ..\windows-files\sscanf.dll components\sscanf.dll
           
           mkdir plugins
-          copy ..\sscanf.dll plugins\sscanf.dll
+          copy ..\windows-files\sscanf.dll plugins\sscanf.dll
           
           mkdir pawno
           cd pawno
           mkdir include
-          copy ..\..\sscanf2.inc include\sscanf2.inc
+          copy ..\..\windows-files\sscanf2.inc include\sscanf2.inc
           cd ..
           
           mkdir qawno
           cd qawno
           mkdir include
-          copy ..\..\sscanf2.inc include\sscanf2.inc
+          copy ..\..\windows-files\sscanf2.inc include\sscanf2.inc
           cd ..
           
           7z a -tzip windows-$env:VERSION.zip *
@@ -176,33 +171,33 @@ jobs:
             
       - name: Create Linux package
         run: |
-          if (-not (Test-Path "sscanf.so")) { throw "sscanf.so not found!" }
+          if (-not (Test-Path "linux-files/sscanf.so")) { throw "Linux sscanf.so not found!" }
           
           mkdir linux-package
           cd linux-package
           
-          copy ..\sscanf.so amxsscanf.so
-          copy ..\LICENSE LICENSE
-          copy ..\pawn.json pawn.json
-          copy ..\README.md README.md
-          copy ..\sscanf2.inc .\
+          copy ..\linux-files\sscanf.so amxsscanf.so
+          copy ..\linux-files\LICENSE LICENSE
+          copy ..\linux-files\pawn.json pawn.json
+          copy ..\linux-files\README.md README.md
+          copy ..\linux-files\sscanf2.inc .\
           
           mkdir components
-          copy ..\sscanf.so components\sscanf.so
+          copy ..\linux-files\sscanf.so components\sscanf.so
           
           mkdir plugins
-          copy ..\sscanf.so plugins\sscanf.so
+          copy ..\linux-files\sscanf.so plugins\sscanf.so
           
           mkdir pawno
           cd pawno
           mkdir include
-          copy ..\..\sscanf2.inc include\sscanf2.inc
+          copy ..\..\linux-files\sscanf2.inc include\sscanf2.inc
           cd ..
           
           mkdir qawno
           cd qawno
           mkdir include
-          copy ..\..\sscanf2.inc include\sscanf2.inc
+          copy ..\..\linux-files\sscanf2.inc include\sscanf2.inc
           cd ..
           
           7z a -ttar -so -an * | 7z a -si linux-$env:VERSION.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,14 @@ jobs:
           $version = "${{ github.ref_name }}".Substring(1)
           echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VERSION_SHORT=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "ARTIFACT_NAME=sscanf-$version-win32" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Set default version (for non-tag builds)
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |
           echo "VERSION=2.15.1" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VERSION_SHORT=2.15.1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "ARTIFACT_NAME=sscanf-2.15.1-win32" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Check CMake version
         run: cmake --version
@@ -57,10 +59,13 @@ jobs:
 
       - name: Create Windows package structure
         run: |
-          mkdir -p sscanf-$env:VERSION_SHORT-win32/plugins
-          mkdir -p sscanf-$env:VERSION_SHORT-win32/components
-          mkdir -p sscanf-$env:VERSION_SHORT-win32/pawno/include
-          mkdir -p sscanf-$env:VERSION_SHORT-win32/qawno/include
+          mkdir sscanf-$env:VERSION_SHORT-win32
+          mkdir sscanf-$env:VERSION_SHORT-win32/plugins
+          mkdir sscanf-$env:VERSION_SHORT-win32/components
+          mkdir sscanf-$env:VERSION_SHORT-win32/pawno
+          mkdir sscanf-$env:VERSION_SHORT-win32/pawno/include
+          mkdir sscanf-$env:VERSION_SHORT-win32/qawno
+          mkdir sscanf-$env:VERSION_SHORT-win32/qawno/include
           
           copy build/Release/sscanf.dll sscanf-$env:VERSION_SHORT-win32/amxsscanf.dll
           copy build/Release/sscanf.dll sscanf-$env:VERSION_SHORT-win32/plugins/sscanf.dll
@@ -71,17 +76,26 @@ jobs:
           copy LICENSE sscanf-$env:VERSION_SHORT-win32/
           copy pawn.json sscanf-$env:VERSION_SHORT-win32/
           copy README.md sscanf-$env:VERSION_SHORT-win32/
-          
+
+      - name: Check created directory structure
+        run: |
+          echo "Directory structure:"
+          Get-ChildItem -Recurse sscanf-$env:VERSION_SHORT-win32
+
       - name: Create Windows zip archive
         run: |
-          7z a -tzip sscanf-$env:VERSION_SHORT-win32.zip sscanf-$env:VERSION_SHORT-win32/*
+          7z a -tzip sscanf-$env:VERSION_SHORT-win32.zip .\sscanf-$env:VERSION_SHORT-win32\*
+          
+      - name: Check created archive
+        run: |
+          echo "Created files:"
+          Get-ChildItem *.zip
           
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sscanf-$env:VERSION_SHORT-win32
-          path: |
-            sscanf-$env:VERSION_SHORT-win32.zip
+          name: $env:ARTIFACT_NAME
+          path: sscanf-$env:VERSION_SHORT-win32.zip
 
   build-linux-release:
     runs-on: ubuntu-latest
@@ -99,17 +113,19 @@ jobs:
           version="${version#v}"
           echo "VERSION=$version" >> $GITHUB_ENV
           echo "VERSION_SHORT=$version" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=sscanf-$version-linux" >> $GITHUB_ENV
 
       - name: Set default version (for non-tag builds)
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |
           echo "VERSION=2.15.1" >> $GITHUB_ENV
           echo "VERSION_SHORT=2.15.1" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=sscanf-2.15.1-linux" >> $GITHUB_ENV
 
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install g++-multilib cmake p7zip-full
+          sudo apt-get install g++-multilib cmake
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -132,6 +148,7 @@ jobs:
 
       - name: Create Linux package structure
         run: |
+          # Переименовываем библиотеку
           cd build
           mv ./libsscanf.so ./sscanf.so
           cd ..
@@ -150,14 +167,23 @@ jobs:
           cp LICENSE sscanf-$VERSION_SHORT-linux/
           cp pawn.json sscanf-$VERSION_SHORT-linux/
           cp README.md sscanf-$VERSION_SHORT-linux/
-          
+
+      - name: Check created directory structure
+        run: |
+          echo "Directory structure:"
+          find sscanf-$VERSION_SHORT-linux -type f
+
       - name: Create Linux tar.gz archive
         run: |
           tar -czf sscanf-$VERSION_SHORT-linux.tar.gz -C sscanf-$VERSION_SHORT-linux .
           
+      - name: Check created archive
+        run: |
+          echo "Created files:"
+          ls -la *.tar.gz
+          
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sscanf-$VERSION_SHORT-linux
-          path: |
-            sscanf-$VERSION_SHORT-linux.tar.gz
+          name: $ARTIFACT_NAME
+          path: sscanf-$VERSION_SHORT-linux.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,17 +117,33 @@ jobs:
         with:
           name: linux-build
         
-      - name: List downloaded files (debug)
-        run: dir /b
-        
-      - name: Get version from tag
-        id: get_version
+      - name: Check current directory and list files
         run: |
-          if ("$env:GITHUB_REF" -like "refs/tags/v*") {
-            $version = $env:GITHUB_REF -replace 'refs/tags/v',''
-          } else {
-            $version = $env:GITHUB_SHA.Substring(0, 7)
+          echo "Current directory: $pwd"
+          echo "=== Files in root ==="
+          Get-ChildItem -Path . -Force
+          echo "=== Windows-build files ==="
+          if (Test-Path "windows-build") { Get-ChildItem -Path "windows-build" -Force }
+          echo "=== Linux-build files ==="  
+          if (Test-Path "linux-build") { Get-ChildItem -Path "linux-build" -Force }
+        
+      - name: Move files to workspace root
+        run: |
+          if (Test-Path "windows-build") {
+            Move-Item -Path "windows-build\*" -Destination "." -Force
+            Remove-Item -Path "windows-build" -Recurse -Force
           }
+          if (Test-Path "linux-build") {
+            Move-Item -Path "linux-build\*" -Destination "." -Force
+            Remove-Item -Path "linux-build" -Recurse -Force
+          }
+          
+          echo "=== Files after moving ==="
+          Get-ChildItem -Path . -Force
+        
+      - name: Get version
+        run: |
+          $version = $env:GITHUB_SHA.Substring(0, 7)
           echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "Version: $version"
             
@@ -136,9 +152,9 @@ jobs:
             
       - name: Create Windows package
         run: |
-          dir /b
-          dir /b *.dll
-          dir /b *.inc
+          if (-not (Test-Path "sscanf.dll")) { throw "sscanf.dll not found!" }
+          if (-not (Test-Path "sscanf2.inc")) { throw "sscanf2.inc not found!" }
+          if (-not (Test-Path "LICENSE")) { throw "LICENSE not found!" }
           
           mkdir windows
           cd windows
@@ -147,7 +163,6 @@ jobs:
           copy ..\LICENSE LICENSE
           copy ..\pawn.json pawn.json
           copy ..\README.md README.md
-          copy ..\sscanf2.inc .\
           
           mkdir components
           copy ..\sscanf.dll components\sscanf.dll
@@ -172,7 +187,7 @@ jobs:
             
       - name: Create Linux package
         run: |
-          dir /b *.so
+          if (-not (Test-Path "sscanf.so")) { throw "sscanf.so not found!" }
           
           mkdir linux
           cd linux
@@ -181,7 +196,6 @@ jobs:
           copy ..\LICENSE LICENSE
           copy ..\pawn.json pawn.json
           copy ..\README.md README.md
-          copy ..\sscanf2.inc .\
           
           mkdir components
           copy ..\sscanf.so components\sscanf.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,35 +111,25 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: windows-build
+          path: ./
         
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4
         with:
           name: linux-build
+          path: ./
         
-      - name: Check current directory and list files
+      - name: Check files structure
         run: |
-          echo "Current directory: $pwd"
-          echo "=== Files in root ==="
+          echo "=== Files in current directory ==="
           Get-ChildItem -Path . -Force
-          echo "=== Windows-build files ==="
-          if (Test-Path "windows-build") { Get-ChildItem -Path "windows-build" -Force }
-          echo "=== Linux-build files ==="  
-          if (Test-Path "linux-build") { Get-ChildItem -Path "linux-build" -Force }
-        
-      - name: Move files to workspace root
-        run: |
-          if (Test-Path "windows-build") {
-            Move-Item -Path "windows-build\*" -Destination "." -Force
-            Remove-Item -Path "windows-build" -Recurse -Force
-          }
-          if (Test-Path "linux-build") {
-            Move-Item -Path "linux-build\*" -Destination "." -Force
-            Remove-Item -Path "linux-build" -Recurse -Force
-          }
-          
-          echo "=== Files after moving ==="
-          Get-ChildItem -Path . -Force
+          echo "=== Checking for required files ==="
+          if (Test-Path "sscanf.dll") { echo "✓ sscanf.dll found" } else { echo "✗ sscanf.dll missing" }
+          if (Test-Path "sscanf.so") { echo "✓ sscanf.so found" } else { echo "✗ sscanf.so missing" }
+          if (Test-Path "sscanf2.inc") { echo "✓ sscanf2.inc found" } else { echo "✗ sscanf2.inc missing" }
+          if (Test-Path "LICENSE") { echo "✓ LICENSE found" } else { echo "✗ LICENSE missing" }
+          if (Test-Path "pawn.json") { echo "✓ pawn.json found" } else { echo "✗ pawn.json missing" }
+          if (Test-Path "README.md") { echo "✓ README.md found" } else { echo "✗ README.md missing" }
         
       - name: Get version
         run: |
@@ -153,16 +143,15 @@ jobs:
       - name: Create Windows package
         run: |
           if (-not (Test-Path "sscanf.dll")) { throw "sscanf.dll not found!" }
-          if (-not (Test-Path "sscanf2.inc")) { throw "sscanf2.inc not found!" }
-          if (-not (Test-Path "LICENSE")) { throw "LICENSE not found!" }
           
-          mkdir windows
-          cd windows
+          mkdir windows-package
+          cd windows-package
           
           copy ..\sscanf.dll amxsscanf.dll
           copy ..\LICENSE LICENSE
           copy ..\pawn.json pawn.json
           copy ..\README.md README.md
+          copy ..\sscanf2.inc .\
           
           mkdir components
           copy ..\sscanf.dll components\sscanf.dll
@@ -189,13 +178,14 @@ jobs:
         run: |
           if (-not (Test-Path "sscanf.so")) { throw "sscanf.so not found!" }
           
-          mkdir linux
-          cd linux
+          mkdir linux-package
+          cd linux-package
           
           copy ..\sscanf.so amxsscanf.so
           copy ..\LICENSE LICENSE
           copy ..\pawn.json pawn.json
           copy ..\README.md README.md
+          copy ..\sscanf2.inc .\
           
           mkdir components
           copy ..\sscanf.so components\sscanf.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,9 +122,9 @@ jobs:
       - name: Check files structure
         run: |
           echo "=== Windows files ==="
-          Get-ChildItem -Path "windows-files" -Force
+          Get-ChildItem -Path "windows-files" -Recurse -Force
           echo "=== Linux files ==="
-          Get-ChildItem -Path "linux-files" -Force
+          Get-ChildItem -Path "linux-files" -Recurse -Force
         
       - name: Get version
         run: |
@@ -137,22 +137,27 @@ jobs:
             
       - name: Create Windows package
         run: |
-          if (-not (Test-Path "windows-files/sscanf.dll")) { throw "Windows sscanf.dll not found!" }
+          $dllPath = "windows-files/build/Release/sscanf.dll"
+          if (-not (Test-Path $dllPath)) { 
+            Write-Host "Available files:"
+            Get-ChildItem -Path "windows-files" -Recurse
+            throw "Windows sscanf.dll not found at: $dllPath" 
+          }
           
           mkdir windows-package
           cd windows-package
           
-          copy ..\windows-files\sscanf.dll amxsscanf.dll
+          copy "..\$dllPath" amxsscanf.dll
           copy ..\windows-files\LICENSE LICENSE
           copy ..\windows-files\pawn.json pawn.json
           copy ..\windows-files\README.md README.md
           copy ..\windows-files\sscanf2.inc .\
           
           mkdir components
-          copy ..\windows-files\sscanf.dll components\sscanf.dll
+          copy "..\$dllPath" components\sscanf.dll
           
           mkdir plugins
-          copy ..\windows-files\sscanf.dll plugins\sscanf.dll
+          copy "..\$dllPath" plugins\sscanf.dll
           
           mkdir pawno
           cd pawno
@@ -171,22 +176,27 @@ jobs:
             
       - name: Create Linux package
         run: |
-          if (-not (Test-Path "linux-files/sscanf.so")) { throw "Linux sscanf.so not found!" }
+          $soPath = "linux-files/build/sscanf.so"
+          if (-not (Test-Path $soPath)) { 
+            Write-Host "Available files:"
+            Get-ChildItem -Path "linux-files" -Recurse
+            throw "Linux sscanf.so not found at: $soPath" 
+          }
           
           mkdir linux-package
           cd linux-package
           
-          copy ..\linux-files\sscanf.so amxsscanf.so
+          copy "..\$soPath" amxsscanf.so
           copy ..\linux-files\LICENSE LICENSE
           copy ..\linux-files\pawn.json pawn.json
           copy ..\linux-files\README.md README.md
           copy ..\linux-files\sscanf2.inc .\
           
           mkdir components
-          copy ..\linux-files\sscanf.so components\sscanf.so
+          copy "..\$soPath" components\sscanf.so
           
           mkdir plugins
-          copy ..\linux-files\sscanf.so plugins\sscanf.so
+          copy "..\$soPath" plugins\sscanf.so
           
           mkdir pawno
           cd pawno
@@ -208,5 +218,5 @@ jobs:
         with:
           name: release-packages
           path: |
-            windows-$env:VERSION.zip
-            linux-$env:VERSION.tar.gz
+            windows-package/windows-$env:VERSION.zip
+            linux-package/linux-$env:VERSION.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
-name: Build
+name: Build and Release
 
 on:
   workflow_dispatch:
+  push:
+    tags: ['v*']  # Запускаем релиз только при тегах
   push:
     branches:
       - "*"
@@ -44,8 +46,13 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: sscanf-win-release
-          path: build/Release/sscanf.dll
+          name: windows-build
+          path: |
+            build/Release/sscanf.dll
+            sscanf2.inc
+            LICENSE
+            pawn.json
+            README.md
 
   build-linux-release:
     runs-on: ubuntu-latest
@@ -80,13 +87,135 @@ jobs:
           cd build
           cmake --build . --config Release
 
-      - name: Rename libsscanf.so to sscanf.so
+      - name: Rename and upload artifacts
         run: |
           cd build
           mv ./libsscanf.so ./sscanf.so
-
+          
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: sscanf-linux-release
-          path: build/sscanf.so
+          name: linux-build
+          path: |
+            build/sscanf.so
+            sscanf2.inc
+            LICENSE
+            pawn.json
+            README.md
+
+  # НОВЫЙ JOB ДЛЯ СОЗДАНИЯ РЕЛИЗНЫХ ПАКЕТОВ
+  create-release-packages:
+    runs-on: windows-latest
+    needs: [build-windows-release, build-linux-release]
+    if: startsWith(github.ref, 'refs/tags/v')
+    
+    steps:
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-build
+          
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-build
+          
+      - name: Get version from tag
+        id: get_version
+        run: |
+          $version = $env:GITHUB_REF -replace 'refs/tags/v',''
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+          
+      - name: Install 7-Zip
+        run: |
+          choco install 7zip -y
+          
+      - name: Create Windows package
+        run: |
+          # Создаем структуру для Windows
+          mkdir windows
+          cd windows
+          
+          copy ..\sscanf.dll amxsscanf.dll
+          copy ..\LICENSE LICENSE
+          copy ..\pawn.json pawn.json
+          copy ..\README.md README.md
+          
+          mkdir components
+          copy ..\sscanf.dll components\sscanf.dll
+          
+          mkdir plugins
+          copy ..\sscanf.dll plugins\sscanf.dll
+          
+          mkdir pawno
+          cd pawno
+          mkdir include
+          copy ..\..\sscanf2.inc include\sscanf2.inc
+          cd ..
+          
+          mkdir qawno
+          cd qawno
+          mkdir include
+          copy ..\..\sscanf2.inc include\sscanf2.inc
+          cd ..
+          
+          # Создаем архив
+          7z a -tzip windows-$env:VERSION.zip *
+          cd ..
+          
+      - name: Create Linux package
+        run: |
+          # Создаем структуру для Linux
+          mkdir linux
+          cd linux
+          
+          copy ..\sscanf.so amxsscanf.so
+          copy ..\LICENSE LICENSE
+          copy ..\pawn.json pawn.json
+          copy ..\README.md README.md
+          
+          mkdir components
+          copy ..\sscanf.so components\sscanf.so
+          
+          mkdir plugins
+          copy ..\sscanf.so plugins\sscanf.so
+          
+          mkdir pawno
+          cd pawno
+          mkdir include
+          copy ..\..\sscanf2.inc include\sscanf2.inc
+          cd ..
+          
+          mkdir qawno
+          cd qawno
+          mkdir include
+          copy ..\..\sscanf2.inc include\sscanf2.inc
+          cd ..
+          
+          # Создаем tar.gz архив
+          7z a -ttar -so -an * | 7z a -si linux-$env:VERSION.tar.gz
+          cd ..
+          
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            windows-$env:VERSION.zip
+            linux-$env:VERSION.tar.gz
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Automated release packages built from GitHub Actions
+            
+            ## Windows
+            - **windows-${{ env.VERSION }}.zip**: Complete package with DLL and includes
+            
+            ## Linux
+            - **linux-${{ env.VERSION }}.tar.gz**: Complete package with SO and includes
+            
+            ### Contents:
+            - Plugin files (amxsscanf.dll/so)
+            - Components directory
+            - Plugins directory
+            - Pawno/Qawno include files
+            - Documentation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,5 +218,5 @@ jobs:
         with:
           name: release-packages
           path: |
-            windows-package/windows-$env:VERSION.zip
-            linux-package/linux-$env:VERSION.tar.gz
+            windows-$env:VERSION.zip
+            linux-$env:VERSION.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,19 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Extract version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          $version = "${{ github.ref_name }}".Substring(1)
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "VERSION_SHORT=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Set default version (for non-tag builds)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "VERSION=2.15.1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "VERSION_SHORT=2.15.1" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Check CMake version
         run: cmake --version
 
@@ -41,17 +54,34 @@ jobs:
           cd build
           cmake -DCMAKE_BUILD_TYPE=Release .. -G "Visual Studio 17 2022" -A Win32
           cmake --build . --config Release
+
+      - name: Create Windows package structure
+        run: |
+          mkdir -p sscanf-$env:VERSION_SHORT-win32/plugins
+          mkdir -p sscanf-$env:VERSION_SHORT-win32/components
+          mkdir -p sscanf-$env:VERSION_SHORT-win32/pawno/include
+          mkdir -p sscanf-$env:VERSION_SHORT-win32/qawno/include
           
-      - name: Upload artifacts
+          copy build/Release/sscanf.dll sscanf-$env:VERSION_SHORT-win32/amxsscanf.dll
+          copy build/Release/sscanf.dll sscanf-$env:VERSION_SHORT-win32/plugins/sscanf.dll
+          copy build/Release/sscanf.dll sscanf-$env:VERSION_SHORT-win32/components/sscanf.dll
+          copy sscanf2.inc sscanf-$env:VERSION_SHORT-win32/
+          copy sscanf2.inc sscanf-$env:VERSION_SHORT-win32/pawno/include/
+          copy sscanf2.inc sscanf-$env:VERSION_SHORT-win32/qawno/include/
+          copy LICENSE sscanf-$env:VERSION_SHORT-win32/
+          copy pawn.json sscanf-$env:VERSION_SHORT-win32/
+          copy README.md sscanf-$env:VERSION_SHORT-win32/
+          
+      - name: Create Windows zip archive
+        run: |
+          7z a -tzip sscanf-$env:VERSION_SHORT-win32.zip sscanf-$env:VERSION_SHORT-win32/*
+          
+      - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows-build
+          name: sscanf-$env:VERSION_SHORT-win32
           path: |
-            build/Release/sscanf.dll
-            sscanf2.inc
-            LICENSE
-            pawn.json
-            README.md
+            sscanf-$env:VERSION_SHORT-win32.zip
 
   build-linux-release:
     runs-on: ubuntu-latest
@@ -62,10 +92,24 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Extract version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          version="${GITHUB_REF#refs/tags/}"
+          version="${version#v}"
+          echo "VERSION=$version" >> $GITHUB_ENV
+          echo "VERSION_SHORT=$version" >> $GITHUB_ENV
+
+      - name: Set default version (for non-tag builds)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "VERSION=2.15.1" >> $GITHUB_ENV
+          echo "VERSION_SHORT=2.15.1" >> $GITHUB_ENV
+
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install g++-multilib cmake
+          sudo apt-get install g++-multilib cmake p7zip-full
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -86,137 +130,34 @@ jobs:
           cd build
           cmake --build . --config Release
 
-      - name: Rename and upload artifacts
+      - name: Create Linux package structure
         run: |
           cd build
           mv ./libsscanf.so ./sscanf.so
+          cd ..
           
-      - name: Upload artifacts
+          mkdir -p sscanf-$VERSION_SHORT-linux/plugins
+          mkdir -p sscanf-$VERSION_SHORT-linux/components
+          mkdir -p sscanf-$VERSION_SHORT-linux/pawno/include
+          mkdir -p sscanf-$VERSION_SHORT-linux/qawno/include
+          
+          cp build/sscanf.so sscanf-$VERSION_SHORT-linux/amxsscanf.so
+          cp build/sscanf.so sscanf-$VERSION_SHORT-linux/plugins/sscanf.so
+          cp build/sscanf.so sscanf-$VERSION_SHORT-linux/components/sscanf.so
+          cp sscanf2.inc sscanf-$VERSION_SHORT-linux/
+          cp sscanf2.inc sscanf-$VERSION_SHORT-linux/pawno/include/
+          cp sscanf2.inc sscanf-$VERSION_SHORT-linux/qawno/include/
+          cp LICENSE sscanf-$VERSION_SHORT-linux/
+          cp pawn.json sscanf-$VERSION_SHORT-linux/
+          cp README.md sscanf-$VERSION_SHORT-linux/
+          
+      - name: Create Linux tar.gz archive
+        run: |
+          tar -czf sscanf-$VERSION_SHORT-linux.tar.gz -C sscanf-$VERSION_SHORT-linux .
+          
+      - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux-build
+          name: sscanf-$VERSION_SHORT-linux
           path: |
-            build/sscanf.so
-            sscanf2.inc
-            LICENSE
-            pawn.json
-            README.md
-
-  create-release-packages:
-    runs-on: windows-latest
-    needs: [build-windows-release, build-linux-release]
-    
-    steps:
-      - name: Download Windows artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-build
-          path: windows-files/
-        
-      - name: Download Linux artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-build
-          path: linux-files/
-        
-      - name: Check files structure
-        run: |
-          echo "=== Windows files ==="
-          Get-ChildItem -Path "windows-files" -Recurse -Force
-          echo "=== Linux files ==="
-          Get-ChildItem -Path "linux-files" -Recurse -Force
-        
-      - name: Get version
-        run: |
-          $version = $env:GITHUB_SHA.Substring(0, 7)
-          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "Version: $version"
-            
-      - name: Install 7-Zip
-        run: choco install 7zip -y
-            
-      - name: Create Windows package
-        run: |
-          $dllPath = "windows-files/build/Release/sscanf.dll"
-          if (-not (Test-Path $dllPath)) { 
-            Write-Host "Available files:"
-            Get-ChildItem -Path "windows-files" -Recurse
-            throw "Windows sscanf.dll not found at: $dllPath" 
-          }
-          
-          mkdir windows-package
-          cd windows-package
-          
-          copy "..\$dllPath" amxsscanf.dll
-          copy ..\windows-files\LICENSE LICENSE
-          copy ..\windows-files\pawn.json pawn.json
-          copy ..\windows-files\README.md README.md
-          copy ..\windows-files\sscanf2.inc .\
-          
-          mkdir components
-          copy "..\$dllPath" components\sscanf.dll
-          
-          mkdir plugins
-          copy "..\$dllPath" plugins\sscanf.dll
-          
-          mkdir pawno
-          cd pawno
-          mkdir include
-          copy ..\..\windows-files\sscanf2.inc include\sscanf2.inc
-          cd ..
-          
-          mkdir qawno
-          cd qawno
-          mkdir include
-          copy ..\..\windows-files\sscanf2.inc include\sscanf2.inc
-          cd ..
-          
-          7z a -tzip windows-$env:VERSION.zip *
-          cd ..
-            
-      - name: Create Linux package
-        run: |
-          $soPath = "linux-files/build/sscanf.so"
-          if (-not (Test-Path $soPath)) { 
-            Write-Host "Available files:"
-            Get-ChildItem -Path "linux-files" -Recurse
-            throw "Linux sscanf.so not found at: $soPath" 
-          }
-          
-          mkdir linux-package
-          cd linux-package
-          
-          copy "..\$soPath" amxsscanf.so
-          copy ..\linux-files\LICENSE LICENSE
-          copy ..\linux-files\pawn.json pawn.json
-          copy ..\linux-files\README.md README.md
-          copy ..\linux-files\sscanf2.inc .\
-          
-          mkdir components
-          copy "..\$soPath" components\sscanf.so
-          
-          mkdir plugins
-          copy "..\$soPath" plugins\sscanf.so
-          
-          mkdir pawno
-          cd pawno
-          mkdir include
-          copy ..\..\linux-files\sscanf2.inc include\sscanf2.inc
-          cd ..
-          
-          mkdir qawno
-          cd qawno
-          mkdir include
-          copy ..\..\linux-files\sscanf2.inc include\sscanf2.inc
-          cd ..
-          
-          7z a -ttar -so -an * | 7z a -si linux-$env:VERSION.tar.gz
-          cd ..
-            
-      - name: Upload release packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-packages
-          path: |
-            windows-package/*.zip
-            linux-package/*.gz
+            sscanf-$VERSION_SHORT-linux.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,5 +218,5 @@ jobs:
         with:
           name: release-packages
           path: |
-            windows-$env:VERSION.zip
-            linux-$env:VERSION.tar.gz
+            windows-package/windows-$env:VERSION.zip
+            linux-package/linux-$env:VERSION.tar.gz

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/martinmoene/span-lite.git
 [submodule "subhook"]
 	path = subhook
-	url = https://github.com/Zeex/subhook.git
+	url = https://github.com/devbluen/subhook.git

--- a/README.md
+++ b/README.md
@@ -3225,3 +3225,7 @@ the Initial Developer.  All Rights Reserved.
 * `SSCANF_GetErrorSpecifier` to get the error position in failure cases.
 * `SSCANF_Debug` to dump a load of useful debugging information.
 
+### Modification sscanf 2.15.1 - 02/09/2025
+* Added hook `SSCANF_SetPlayerName`.
+* The letters `u`, `q`, `r` have been updated to account for the case and length of the player/bot name. It works when using `MATCH_NAME_SIMILARITY` = `-1.0` (default).
+

--- a/specifiers.cpp
+++ b/specifiers.cpp
@@ -290,7 +290,7 @@ bool
 				// there's no point - it's just extra work and we know it's OK.
 				// We set the null before incrementing to ensure it's included
 				// in the output.
-				SscanfWarning(2, "String buffer overflow.");
+				//SscanfWarning(2, "String buffer overflow.");
 				// Removed the break - discard the rest of the string.
 				//break;
 			}
@@ -330,7 +330,7 @@ bool
 			++i;
 			if (i == length)
 			{
-				SscanfWarning(2, "String buffer overflow.");
+				//SscanfWarning(2, "String buffer overflow.");
 			}
 			else if (i < length)
 			{
@@ -365,7 +365,7 @@ bool
 			++i;
 			if (i == length)
 			{
-				SscanfWarning(2, "String buffer overflow.");
+				//SscanfWarning(2, "String buffer overflow.");
 			}
 			else if (i < length)
 			{
@@ -1369,7 +1369,7 @@ int
 	// Add a null terminator.
 	if (i >= *length)
 	{
-		SscanfWarning(2, "String buffer overflow.");
+		//SscanfWarning(2, "String buffer overflow.");
 		*(*ret + *length - 1) = '\0';
 	}
 	else

--- a/specifiers.cpp
+++ b/specifiers.cpp
@@ -448,7 +448,7 @@ bool
 				while (val < g_iTrueMax)
 				{
 					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && !strincmp(name, string, len))
+					if (*conn && diff >= 0 && !strncmp(name, string, len))
 					{
 						*ret = val;
 						break;
@@ -473,16 +473,16 @@ bool
 				}
 				break;
 			case SSCANF_OPTIONS_NONE:
-				// Original.
+				// Original
 				while (val < g_iTrueMax)
 				{
-					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && !strincmp(name, string, len))
+					if (*conn)
 					{
-						if (diff < best)
+						size_t name_len = strlen(name);
+						if (name_len == len && !strncmp(name, string, len))
 						{
 							*ret = val;
-							best = diff;
+							break;
 						}
 					}
 					++conn;
@@ -514,7 +514,7 @@ bool
 				while (val < g_iTrueMax)
 				{
 					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && !strincmp(name, string, len))
+					if (*conn && diff >= 0 && !strncmp(name, string, len))
 					{
 						if (*ret != g_iInvalid)
 						{
@@ -673,7 +673,7 @@ bool
 				while (val < g_iTrueMax)
 				{
 					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && *npc && !strincmp(name, string, len))
+					if (*conn && diff >= 0 && *npc && !strncmp(name, string, len))
 					{
 						*ret = val;
 						break;
@@ -701,16 +701,16 @@ bool
 				}
 				break;
 			case SSCANF_OPTIONS_NONE:
-				// Original.
+				// Original
 				while (val < g_iTrueMax)
 				{
-					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && *npc && !strincmp(name, string, len))
+					if (*conn)
 					{
-						if (diff < best)
+						size_t name_len = strlen(name);
+						if (name_len == len && *npc && !strncmp(name, string, len))
 						{
 							*ret = val;
-							best = diff;
+							break;
 						}
 					}
 					++conn;
@@ -744,7 +744,7 @@ bool
 				while (val < g_iTrueMax)
 				{
 					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && *npc && !strincmp(name, string, len))
+					if (*conn && diff >= 0 && *npc && !strncmp(name, string, len))
 					{
 						if (*ret != g_iInvalid)
 						{
@@ -902,7 +902,7 @@ bool
 				while (val < g_iTrueMax)
 				{
 					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && !*npc && !strincmp(name, string, len))
+					if (*conn && diff >= 0 && !*npc && !strncmp(name, string, len))
 					{
 						*ret = val;
 						break;
@@ -930,16 +930,16 @@ bool
 				}
 				break;
 			case SSCANF_OPTIONS_NONE:
-				// Original.
+				// Original
 				while (val < g_iTrueMax)
 				{
-					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && !*npc && !strincmp(name, string, len))
+					if (*conn)
 					{
-						if (diff < best)
+						size_t name_len = strlen(name);
+						if (name_len == len && !*npc && !strncmp(name, string, len))
 						{
 							*ret = val;
-							best = diff;
+							break;
 						}
 					}
 					++conn;
@@ -973,7 +973,7 @@ bool
 				while (val < g_iTrueMax)
 				{
 					size_t diff = strlen(name) - len;
-					if (*conn && diff >= 0 && !*npc && !strincmp(name, string, len))
+					if (*conn && diff >= 0 && !*npc && !strncmp(name, string, len))
 					{
 						if (*ret != g_iInvalid)
 						{
@@ -1445,4 +1445,3 @@ int
 	DoL(input, ret);
 	return GetReturnDefault(input);
 }
-

--- a/sscanf2.inc
+++ b/sscanf2.inc
@@ -1355,6 +1355,31 @@ forward OnCachedInit();
 	CHAIN_FORWARD:SSCANF_OnPlayerDisconnect(playerid, reason) = 1;
 #endif
 
+/**
+ * <library>sscanf</library>
+ * <remarks>
+ * Called when a player change names.
+ * </remarks>
+ */
+stock SSCANF__SetPlayerName(playerid, const name[])
+{
+	new 
+			SSCANF_value = SetPlayerName(playerid, name)
+		;
+
+	if (SSCANF_value == 1 && SSCANF_gInit == 1)
+	{
+		SSCANF_Join(playerid, name, bool:IsPlayerNPC(playerid));
+	}
+	return SSCANF_value;
+}
+#if defined _ALS_SetPlayerName
+	#undef SetPlayerName
+#else
+	#define _ALS_SetPlayerName
+#endif
+#define SetPlayerName SSCANF__SetPlayerName
+
 // Ensure that these purely internal natives can't be called from outside this
 // include.
 #define SSCANF_Init
@@ -1405,7 +1430,7 @@ forward OnCachedInit();
 #define EXTRN%0new%1; new%1;
 
 #if !defined string
-    #define string:
+	#define string:
 #endif
 
 #define player:%0;UNFORMAT__(%1) %0;UNFORMAT__(%1)
@@ -2081,11 +2106,11 @@ stock SSCANF_Debug()
 	printf(gap);
 	printf(" | Options:                             |");
 	printf(gap);
-    SSCANF_PrintOption(OLD_DEFAULT_NAME);
-    SSCANF_PrintOption(MATCH_NAME_PARTIAL);
-    SSCANF_PrintOption(CELLMIN_ON_MATCHES);
-    SSCANF_PrintOption(SSCANF_QUIET);
-    SSCANF_PrintOption(OLD_DEFAULT_KUSTOM);
+	SSCANF_PrintOption(OLD_DEFAULT_NAME);
+	SSCANF_PrintOption(MATCH_NAME_PARTIAL);
+	SSCANF_PrintOption(CELLMIN_ON_MATCHES);
+	SSCANF_PrintOption(SSCANF_QUIET);
+	SSCANF_PrintOption(OLD_DEFAULT_KUSTOM);
 	printf(" |     SSCANF_ALPHA:             0x%02x   |", SSCANF_GetOption__(SSCANF_ALPHA));
 	printf(" |     SSCANF_COLOUR_FORMS:      0x%02x   |", forms);
 	printf(" |         #RGB       (0x01):     %s   |", forms & 0x01 ? on : off);
@@ -2095,9 +2120,9 @@ stock SSCANF_Debug()
 	printf(" |         {RRGGBB}   (0x10):     %s   |", forms & 0x10 ? on : off);
 	printf(" |         0xRRGGBBAA (0x20):     %s   |", forms & 0x20 ? on : off);
 	printf(" |         RRGGBBAA   (0x40):     %s   |", forms & 0x40 ? on : off);
-    //SSCANF_PrintOption(SSCANF_COLOUR_FORMS);
-    SSCANF_PrintOption(SSCANF_ARGB);
-    SSCANF_PrintOption(MATCH_NAME_FIRST);
+	//SSCANF_PrintOption(SSCANF_COLOUR_FORMS);
+	SSCANF_PrintOption(SSCANF_ARGB);
+	SSCANF_PrintOption(MATCH_NAME_FIRST);
 	if (similarity < 0.0)
 	{
 		printf(" |     MATCH_NAME_SIMILARITY:     off   |");
@@ -2106,9 +2131,9 @@ stock SSCANF_Debug()
 	{
 		printf(" |     MATCH_NAME_SIMILARITY:  %6.3f   |", similarity);
 	}
-    SSCANF_PrintOption(ERROR_CODE_IN_RET);
-    SSCANF_PrintOption(WARNINGS_AS_ERRORS);
-    SSCANF_PrintOption(ERROR_CATEGORY_ONLY);
+	SSCANF_PrintOption(ERROR_CODE_IN_RET);
+	SSCANF_PrintOption(WARNINGS_AS_ERRORS);
+	SSCANF_PrintOption(ERROR_CATEGORY_ONLY);
 	printf(gap);
 	printf(line);
 	printf(gap);
@@ -2272,7 +2297,7 @@ stock sscanf(string[], format[], {Float,_}:...)
 				while(changepos < 16 && string[strpos] && string[strpos] != delim)
 				{
 					changestr[changepos++] = string[strpos++];
-    				} 
+					} 
 				changestr[changepos] = '\0'; 
 				setarg(paramPos,0,_:floatstr(changestr)); 
 			} 
@@ -2420,4 +2445,3 @@ stock sscanf(string[], format[], {Float,_}:...)
 	while (delim > ' ');
 	return 0;
 }
-


### PR DESCRIPTION
- Added hook SSCANF_SetPlayerName.
- The letters u, q, r have been updated to account for the case and length of the player/bot name. It works when using MATCH_NAME_SIMILARITY = -1.0 (default).

Deleting (comment) SscanfWarning(2, "String buffer overflow.").
He is not needed. When I use it, for example, in a command:
```Pawn
new targetNickName[MAX_PLAYER_NAME + 1];
sscanf(params, "s[*]", MAX_PLAYER_NAME + 1, targetNickName))
```
If the player enters a string length greater than the nickname (MAX_PLAYER_NAME + 1), it outputs this string in the console.